### PR TITLE
More Block Storage methods and a few fixes

### DIFF
--- a/volume.js
+++ b/volume.js
@@ -23,25 +23,34 @@ module.exports = {
 		return this.request(`volumes/${id}`, {val: 'volume'});
 	},
 
+	getVolumeByName: function (name, region) {
+		return this.request(`volumes?name=${name}&region=${region}`, {val: 'volumes'});
+	},
+
 	listVolumeSnapshots: function (id) {
 		const val = 'snapshots';
 		return this.request(`volumes/${id}/${val}`, {val});
 	},
 
-	listVolumeActions: function (id) {
-		const val = 'actions';
-		return this.request(`volumes/${id}/${val}`, {val});
-	},
-
 	takeVolumeSnapshot: function (id, name) {
-		return this.request(getActions(id), {
+		return this.request(`volumes/${id}/snapshots`, {
 			method: 'POST',
-			body: {type: 'snapshot', name}
+			body: {name},
+			val: 'snapshot'
 		});
 	},
 
 	deleteVolume: function (id) {
 		return this.request(`volumes/${id}`, {method: 'DELETE'});
+	},
+
+	deleteVolumeByName: function (name, region) {
+		return this.request(`volumes?name=${name}&region=${region}`, {method: 'DELETE'});
+	},
+
+	listVolumeActions: function (id) {
+		const val = 'actions';
+		return this.request(`volumes/${id}/${val}`, {val});
 	},
 
 	attachVolume: function (volumeId, dropletId) {


### PR DESCRIPTION
Whoops! This is why I shouldn't write PRs right before I go to bed. The reason that the `takeVolumeSnapshot` test was getting an `Unprocessable Entity` response was because it was trying to test on the `nyc3` region, which does not yet support Block Storage. By changing this test to use `nyc1`, the test returns a `Not Found` response, as expected.

The `createVolume` test also wasn't actually creating a volume. I've modified it to actually work, and added a few lines which will now fail the test if a volume isn't actually made.

I also realized that I didn't add the `getVolumeByName` and `deleteVolumeByName` methods, which are actually the only two methods I need for my project haha.

I apologize for this being a messy PR that does four separate things all at once, I can make cleaner, more focused PRs going forward.