### PR TITLE
add listRegions method

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,8 @@ API.prototype.inject(
 	require('./domain'),
 	require('./droplet'),
 	require('./image'),
-	require('./volume')
+	require('./volume'),
+	require('./region')
 );
 
 // send out everything!

--- a/region.js
+++ b/region.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = {
+	listRegions: function () {
+		const val = 'regions';
+		return this.request(val, {val});
+	}
+};

--- a/test/index.js
+++ b/test/index.js
@@ -226,3 +226,7 @@ test('Volume.resizeVolume(id, size)', async t => {
 	const res = await t.notThrows(API.resizeVolume(FAKE.VOLUME, FAKE.SIZE_GIGABYTES));
 	isNotFound(t, res);
 });
+
+test.only('Region.listRegions()', async t => {
+	await t.notThrows(API.listRegions());
+});


### PR DESCRIPTION
Useful for applications that wish to employ Block Storage, as they need to query the list of regions to determine which of them support Block Storage ([Example output](https://gist.github.com/Lange/662404f8233cf53f5a023e2f83823654)).

I'm also going to be opening another PR today or tomorrow to add support for [Floating IPs](https://developers.digitalocean.com/documentation/v2/#floating-ips).