### PR TITLE
fix the Volume.listVolumeActions(id) test

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -204,7 +204,8 @@ test('Volume.deleteVolumeByName(name, region)', async t => {
 
 test('Volume.listVolumeActions(id)', async t => {
 	const res = await API.listVolumeActions(FAKE.VOLUME);
-	t.deepEqual(res, [], 'is empty array');
+	t.true(Array.isArray(res));
+	t.true(res.length > 0);
 });
 
 test('Volume.takeVolumeSnapshot(id, name)', async t => {


### PR DESCRIPTION
The volume represented by FAKE.VOLUME now has actions in its history, so the array it returns is not empty.